### PR TITLE
Adds in rest support for gutenberg capabilities

### DIFF
--- a/api/partials/post-type/register-post-type.txt
+++ b/api/partials/post-type/register-post-type.txt
@@ -44,6 +44,7 @@
 							'with_front' => FALSE,
 						],
 						'capability_type'     => 'post',
+						'show_in_rest'        => TRUE,
 					]
 				)
 			);

--- a/api/partials/post-type/register-taxonomy.txt
+++ b/api/partials/post-type/register-taxonomy.txt
@@ -27,6 +27,7 @@
 					'query_var'         => TRUE,
 					'public'            => TRUE,
 					'show_admin_column' => TRUE,
+					'show_in_rest'      => TRUE,
 				] )
 			);
 


### PR DESCRIPTION
Added `show_in_rest` to the post and taxonomy generators for Gutenberg editor support for custom post types. Taxonomies will now appear in the sidebar on the Gutenberg editor.